### PR TITLE
Update the README & add the old logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,9 @@
-# KucherX
+# Yukon – the OpenCyphal IDE
 
-KucherX is a simple user-friendly GUI application designed for configuration, diagnostics,
-and maintenance of [Cyphal](https://opencyphal.org/)-enabled Zubax hardware.
-It is a tool for:
+[![Forum](https://img.shields.io/discourse/users.svg?server=https%3A%2F%2Fforum.opencyphal.org&color=1700b3)](https://forum.opencyphal.org)
 
-- Configuration and diagnostics of Cyphal-enabled hardware manufactured by Zubax.
-- Visualization of data from Cyphal subjects and registers in real-time (online, on a live network).
-- Exporting of the data captured from the live network for offline analysis (using Pandas, PlotJuggler, MATLAB, etc.)
+<p align="center"><img src="/docs/yukon.svg" width="40%"></p>
 
-KucherX does not aim to be a general-purpose Cyphal diagnostics tool.
-If you need that, consider using [Yakut](https://github.com/OpenCyphal/yakut) instead.
-
-KucherX is compatible with GNU/Linux and Windows.
-
-We can relicense this project under the [MIT license](https://opensource.org/licenses/MIT). When we remove dynamic
-linking to QT. At the moment we are using a webview from QT but there are so many more options to choose from. 
-One of the most obvious choices is to just use a web browser and a server setup. It is also possible to use any of
-the other web window providers from pywebview.
-
+Yukon is a rich integrated development environment (IDE) for developing and maintaining
+[OpenCyphal](https://opencyphal.org)-powered vehicular computing systems.
+It is designed to run on GNU/Linux, Windows, and macOS.

--- a/docs/yukon.svg
+++ b/docs/yukon.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.1" viewBox="575 806 170.71977 66.576912" width="170.71977" height="66.576912" id="svg33" sodipodi:docname="logo.svg" inkscape:version="1.0 (4035a4fb49, 2020-05-01)" inkscape:export-filename="/home/pavel/Downloads/Yukon.png" inkscape:export-xdpi="1000" inkscape:export-ydpi="1000">
+  
+  
+  <defs id="defs4"/>
+  <g transform="translate(5.28,-6)" id="Graphic_3" style="fill:none;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <line x1="626.125" y1="855.59369" x2="626.125" y2="864.5769" fill="#1700b3" id="line14"/>
+    <line x1="626.125" y1="855.59369" x2="626.125" y2="864.5769" stroke="#1700b3" stroke-linecap="butt" stroke-linejoin="round" stroke-width="2" id="line16"/>
+  </g>
+  <g transform="translate(5.28,-6)" id="Graphic_2" style="fill:none;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1">
+    <circle cx="626.125" cy="864.5769" r="4.0000052" fill="#1700b3" id="circle21"/>
+    <circle cx="626.125" cy="864.5769" r="4.0000052" stroke="#1700b3" stroke-linecap="butt" stroke-linejoin="round" stroke-width="0" id="circle23"/>
+  </g>
+  <g style="fill:#1600b4;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1" id="text28" aria-label="yUkon">
+    <path id="path881" style="font-weight:400;font-size:48px;font-family:'Russo One';fill:#1600b4" d="m 594.59998,858.23998 q -2.544,0 -6.24,-0.48 v -6.24 h 4.32 q 1.824,0 2.352,-1.008 0.576,-1.008 -0.192,-2.832 l -9.84,-23.52 h 8.88 l 6,16.32 5.04,-16.32 h 8.88 l -9.6,26.4 q -1.392,3.792 -3.6,5.712 -2.208,1.968 -6,1.968 z"/>
+    <path id="path883" style="font-weight:400;font-size:48px;font-family:'Russo One';fill:#1600b4" d="m 637.31997,815.99998 h 8.64 v 24.48 q 0,5.04 -2.304,7.344 -2.256,2.256 -7.296,2.256 h -11.04 q -5.04,0 -7.344,-2.256 -2.256,-2.304 -2.256,-7.344 v -24.48 h 8.64 v 24.48 q 0,2.88 2.88,2.88 h 7.2 q 2.88,0 2.88,-2.88 z"/>
+    <path id="path885" style="font-weight:400;font-size:48px;font-family:'Russo One';fill:#1600b4" d="m 659.63987,839.51998 v 10.08 h -8.4 v -33.6 h 8.4 v 17.04 h 3.84 l 5.28,-8.88 h 8.88 l -7.2,12.24 7.2,13.2 h -8.88 l -5.52,-10.08 z"/>
+    <path id="path887" style="font-weight:400;font-size:48px;font-family:'Russo One';fill:#1600b4" d="m 705.47979,842.39998 q 0,3.6 -2.064,5.664 -2.016,2.016 -5.616,2.016 h -11.04 q -3.6,0 -5.664,-2.016 -2.016,-2.064 -2.016,-5.664 v -11.04 q 0,-3.6 2.016,-5.616 2.064,-2.064 5.664,-2.064 h 11.04 q 3.6,0 5.616,2.064 2.064,2.016 2.064,5.616 z m -8.4,-10.32 q 0,-1.92 -1.92,-1.92 h -5.76 q -1.92,0 -1.92,1.92 v 9.6 q 0,1.92 1.92,1.92 h 5.76 q 1.92,0 1.92,-1.92 z"/>
+    <path id="path889" style="font-weight:400;font-size:48px;font-family:'Russo One';fill:#1600b4" d="m 723.95975,830.63998 q -2.544,0 -5.76,0.96 v 18 h -8.4 v -25.44 h 7.44 l 0.48,2.4 q 2.256,-1.488 4.608,-2.16 2.4,-0.72 4.032,-0.72 h 2.16 q 3.264,0 5.232,1.968 1.968,1.968 1.968,5.232 v 18.72 h -8.4 v -17.28 q 0,-0.72 -0.48,-1.2 -0.48,-0.48 -1.2,-0.48 z"/>
+  </g>
+</svg>


### PR DESCRIPTION
This is the old logo that references the old UAVCAN project logo. I am not sure whether it is appropriate, may need to revisit it later.

@silverv I suppose the color scheme will need to follow this instead of `#e00000`: https://forum.opencyphal.org/t/pr-preparations-for-the-upcoming-uavcan-v1-0-release-new-website-new-logo/353/28?u=pavel.kirienko