### PR TITLE
Add links to binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Yukon – the OpenCyphal IDE
 
 [![Forum](https://img.shields.io/discourse/users.svg?server=https%3A%2F%2Fforum.opencyphal.org&color=1700b3)](https://forum.opencyphal.org)
+[![Download](https://img.shields.io/badge/download-GNU%2BLinux-%23b00036)](https://files.zubax.com/products/org.opencyphal.yukon/releases)
+[![Download](https://img.shields.io/badge/download-Windows-%23b00036)](https://files.zubax.com/products/org.opencyphal.yukon/releases)
 
 <p align="center"><img src="/docs/yukon.svg" width="40%"></p>
 
 Yukon is a rich integrated development environment (IDE) for developing and maintaining
 [OpenCyphal](https://opencyphal.org)-powered vehicular computing systems.
 It is designed to run on GNU/Linux, Windows, and macOS.
+
+**Download pre-built executables from
+[files.zubax.com/products/org.opencyphal.yukon](https://files.zubax.com/products/org.opencyphal.yukon/releases).**


### PR DESCRIPTION
The GNU/Linux and Windows badges point to the same location, this is intentional.

@silverv pls merge